### PR TITLE
Travis: drop unsupported node versions, add stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - "stable"
   - "0.10"
   - "0.12"
-  - "0.13"
-  - "iojs"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.13"


### PR DESCRIPTION
Drop io.js and 0.13, both which are no longer supported. Add 'stable' to test plan.
